### PR TITLE
Fix typo in auto_ml_swm docstring

### DIFF
--- a/ml/auto_ml_swm.py
+++ b/ml/auto_ml_swm.py
@@ -1,5 +1,5 @@
 """
-AutoML pipeline for accidently classifying sections of the SWM Food Safety Plan.
+AutoML pipeline for accidentally classifying sections of the SWM Food Safety Plan.
 This script:
  1. Reads the cleaned Markdown.
  2. Splits it into sections (by header).


### PR DESCRIPTION
## Summary
- correct `accidently` typo in `ml/auto_ml_swm.py`

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_b_6888581b9c9c8321a68993a3f5693a63